### PR TITLE
fix: fix babel proposal-class-properties

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,6 +10,15 @@
             }
           }
         ]
+      ],
+      "plugins": [
+        [
+          // See https://stackoverflow.com/a/52351194
+          "@babel/plugin-proposal-class-properties",
+          {
+            "loose": true
+          }
+        ]
       ]
     }
   }


### PR DESCRIPTION
Fix error `SyntaxError: Support for the experimental syntax 'classProperties' isn't currently enabled`.